### PR TITLE
Add writeFull function in p2p.conn

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -36,8 +36,8 @@ const (
 
 	defaultDialTimeout = 15 * time.Second
 
-	// Maximum amount of time allowed for writing a complete message.
-	frameWriteTimeout = 20 * time.Second
+	// Maximum amount of time allowed for writing some bytes, not a complete message, because the message length is very highly variable.
+	connWriteTimeout = 10 * time.Second
 
 	// Maximum time allowed for reading a complete message.
 	frameReadTimeout = 30 * time.Second


### PR DESCRIPTION
Because the length of message can vary from dozens of bytes to several Mega bytes, a const variable frameWriteTimeout can not show the network status.
So add connWriteTimeout instead of frameWriteTimeout, and rewrite conn.writeFull.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seeleteam/go-seele/101)
<!-- Reviewable:end -->
