### PR TITLE
rename several names

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -68,7 +68,7 @@ func (s *Statedb) GetCopy() (*Statedb, error) {
 		}
 	}
 
-	cpyTrie, err := s.trie.ShallowCopyTrie()
+	cpyTrie, err := s.trie.ShallowCopy()
 	if err != nil {
 		return nil, err
 	}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -76,7 +76,7 @@ func NewMiner(addr common.Address, seele SeeleBackend, log *log.SeeleLog) *Miner
 		hashrate:             metrics.NewMeter(),
 	}
 
-	event.BlockDownloaderEventManager.AddAsyncListener(miner.downloadEventCallback)
+	event.BlockDownloaderEventManager.AddAsyncListener(miner.downloaderEventCallback)
 	event.TransactionInsertedEventManager.AddAsyncListener(miner.newTxCallback)
 
 	return miner
@@ -131,8 +131,8 @@ func (miner *Miner) IsMining() bool {
 	return atomic.LoadInt32(&miner.mining) == 1
 }
 
-// downloadEventCallback handles events which indicate the downloader state
-func (miner *Miner) downloadEventCallback(e event.Event) {
+// downloaderEventCallback handles events which indicate the downloader state
+func (miner *Miner) downloaderEventCallback(e event.Event) {
 	if atomic.LoadInt32(&miner.isFirstDownloader) == 0 {
 		return
 	}

--- a/trie/node.go
+++ b/trie/node.go
@@ -6,8 +6,8 @@
 package trie
 
 const (
-	// numBranchNodes number children in branch node
-	numBranchNodes int = 17 // for 0-f branches + value node; reduce the height of tree for performance
+	// numBranchChildren number children in branch node
+	numBranchChildren int = 17 // for 0-f branches + value node; reduce the height of tree for performance
 )
 
 // Noder interface for node
@@ -22,11 +22,11 @@ type Node struct {
 	dirty bool   // is the node dirty,need to write to database
 }
 
-// ExtendNode is extend node struct
-type ExtendNode struct {
+// ExtensionNode is extension node struct
+type ExtensionNode struct {
 	Node
 	Key      []byte // for shared nibbles
-	Nextnode noder  // for next node
+	NextNode noder  // for next node
 }
 
 // LeafNode is leaf node struct
@@ -39,10 +39,10 @@ type LeafNode struct {
 // BranchNode is node for branch
 type BranchNode struct {
 	Node
-	Children [numBranchNodes]noder
+	Children [numBranchChildren]noder
 }
 
-// hashNode is just used by nextnode of ExtendNode
+// hashNode is just used by NextNode of ExtensionNode
 // when it does not load real node from database
 type hashNode []byte
 


### PR DESCRIPTION
the following changes are based on the corresponding meaning or context: 
1.  miner.downloadEventCallback:  rename to downloaderEventCallback
2.  node.numBranchNodes, ExtendNode, Nextnode:  rename to numBranchChildren, ExtensionNode, NextNode separately
3.  trie.ShallowCopyTrie:  rename to ShallowCopy
4.  trie.insertExtentNode, decodeExtendNode:  rename to insertExtensionNode, decodeExtensionNode separately

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seeleteam/go-seele/166)
<!-- Reviewable:end -->
