### PR TITLE
fix bugs in task and event

### DIFF
--- a/event/manager.go
+++ b/event/manager.go
@@ -17,21 +17,23 @@ type EventManager struct {
 	listeners []eventListener
 }
 
-// Fire fires the event and returns it after all listeners have done
-// their jobs.
+// Fire triggers all listeners with the specified event and removes listeners which run only once.
 func (h *EventManager) Fire(e Event) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
-
-	for _, l := range h.listeners {
+    
+	listeners := make([]eventListener, len(h.listeners))
+	copy(listeners, h.listeners)
+	
+	h.removeOnceListener()
+	
+	for _, l := range listeners {
 		if l.IsAsyncListener {
 			go l.Callable(e)
 		} else {
 			l.Callable(e)
 		}
 	}
-
-	h.removeOnceListener()
 }
 
 // AddListener registers a listener.
@@ -101,14 +103,17 @@ func (h *EventManager) RemoveListener(callback EventHandleMethod) {
 
 // removeOnceListener removes all listeners which run only once
 func (h *EventManager) removeOnceListener() {
-	listener := make([]eventListener, 0, len(h.listeners))
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	
+	listeners := make([]eventListener, 0, len(h.listeners))
 	for _, l := range h.listeners {
 		if !l.IsOnceListener {
-			listener = append(listener, l)
+			listeners = append(listeners, l)
 		}
 	}
 
-	h.listeners = listener
+	h.listeners = listeners
 }
 
 // find finds listener existing in the manager

--- a/event/manager.go
+++ b/event/manager.go
@@ -102,10 +102,7 @@ func (h *EventManager) RemoveListener(callback EventHandleMethod) {
 }
 
 // removeOnceListener removes all listeners which run only once
-func (h *EventManager) removeOnceListener() {
-	h.lock.Lock()
-	defer h.lock.Unlock()
-	
+func (h *EventManager) removeOnceListener() {	
 	listeners := make([]eventListener, 0, len(h.listeners))
 	for _, l := range h.listeners {
 		if !l.IsOnceListener {

--- a/event/manager.go
+++ b/event/manager.go
@@ -21,19 +21,16 @@ type EventManager struct {
 func (h *EventManager) Fire(e Event) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
-    
-	listeners := make([]eventListener, len(h.listeners))
-	copy(listeners, h.listeners)
 	
-	h.removeOnceListener()
-	
-	for _, l := range listeners {
+	for _, l := range h.listeners {
 		if l.IsAsyncListener {
 			go l.Callable(e)
 		} else {
 			l.Callable(e)
 		}
 	}
+
+	h.removeOnceListener()
 }
 
 // AddListener registers a listener.

--- a/miner/task.go
+++ b/miner/task.go
@@ -53,7 +53,7 @@ func (task *Task) applyTransactions(seele SeeleBackend, statedb *state.Statedb, 
 }
 
 func (task *Task) chooseTransactions(seele SeeleBackend, statedb *state.Statedb, txs map[common.Address][]*types.Transaction, log *log.SeeleLog) {
-	for i := 0; i < core.BlockTransactionNumberLimit; i++ {
+	for i := 0; i < core.BlockTransactionNumberLimit - 1; i++ {
 		tx := popBestFeeTx(txs)
 		if tx == nil {
 			break


### PR DESCRIPTION
1. miner/task.go:  as a result of miner reward is considered as a transaction,  in the condition clause of task.chooseTransactions, BlockTransactionNumberLimit should be replaced with BlockTransactionNumberLimit - 1.  otherwise,  blockchain.validateBlock will fail if the number of txs is up to the maximum
2. event/manager.go:  in event.Fire, we should remove listeners before they are invoked in case that a listener callback will add itself again. if not, the attempt to register itself once again could fail. because it can occur before the ultimate removing for either uncertainty of goroutine or multiple sync callback
3. event/manager.go:  add lock in removeOnceListener, even though it's only called by Fire.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seeleteam/go-seele/183)
<!-- Reviewable:end -->
