### PR TITLE
Add shard in seele module

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -14,6 +14,9 @@ import (
 	"reflect"
 	"sync"
 
+	"github.com/seeleteam/go-seele/p2p/discovery"
+
+	"github.com/seeleteam/go-seele/common"
 	"github.com/seeleteam/go-seele/log"
 	"github.com/seeleteam/go-seele/p2p"
 	"github.com/seeleteam/go-seele/rpc"
@@ -88,6 +91,12 @@ func (n *Node) Start() error {
 	if n.server != nil {
 		return ErrNodeRunning
 	}
+
+	// TODO try load shardid from config if it exists
+	// TODO try load blockchain from directory, it must match with config
+	// TODO try load coinbase, it must match with shardid.
+	// if shardid can not be determined, it should be set by discovery routine in p2p.server.
+	common.LocalShardNumber = discovery.UndefinedShardNumber
 
 	n.serverConfig = n.config.P2PConfig
 	running := p2p.NewServer(n.serverConfig)


### PR DESCRIPTION
Create different handle message function for other shard peers, that will handle no message
Broadcast transactions accroding to shardid. 
Shardid of transaction is determined by it from address

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seeleteam/go-seele/206)
<!-- Reviewable:end -->
