### PR TITLE
fix bug in db_store

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -380,19 +380,23 @@ func (bc *Blockchain) updateStateDB(statedb *state.Statedb, minerRewardTx *types
 	stateObj := statedb.GetOrNewStateObject(*minerRewardTx.Data.To)
 	stateObj.AddAmount(minerRewardTx.Data.Amount)
 
-	receipts := make([]*types.Receipt, len(txs))
+	receipts := make([]*types.Receipt, len(txs)+1)
+	
+	// add the receipt of the reward tx
+	receipts[0] = types.MakeRewardReceipt(minerRewardTx)
+	
 	// process other txs
 	for i, tx := range txs {
 		if err := tx.Validate(statedb); err != nil {
 			return nil, err
 		}
 
-		receipt, err := bc.ApplyTransaction(tx, i, *minerRewardTx.Data.To, statedb, blockHeader)
+		receipt, err := bc.ApplyTransaction(tx, i+1, *minerRewardTx.Data.To, statedb, blockHeader)
 		if err != nil {
 			return nil, err
 		}
 
-		receipts[i] = receipt
+		receipts[i+1] = receipt
 	}
 
 	return receipts, nil

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -58,3 +58,10 @@ func ReceiptMerkleRootHash(receipts []*Receipt) common.Hash {
 
 	return bmt.MerkleRoot()
 }
+
+// MakeRewardReceipt generates the receipt for the specified reward transaction
+func MakeRewardReceipt(reward *Transaction) *Receipt {
+    return &Receipt{
+	    TxHash: reward.Hash,
+	}
+}

--- a/miner/task.go
+++ b/miner/task.go
@@ -40,6 +40,9 @@ func (task *Task) applyTransactions(seele SeeleBackend, statedb *state.Statedb, 
 	stateObj := statedb.GetOrNewStateObject(seele.GetCoinbase())
 	stateObj.AddAmount(rewardValue)
 	task.txs = append(task.txs, reward)
+	
+	// add the receipt of the reward tx
+	task.receipts = append(task.receipts, types.MakeRewardReceipt(reward))
 
 	task.chooseTransactions(seele, statedb, txs, log)
 
@@ -70,7 +73,7 @@ func (task *Task) chooseTransactions(seele SeeleBackend, statedb *state.Statedb,
 			continue
 		}
 
-		receipt, err := seele.BlockChain().ApplyTransaction(tx, i, seele.GetCoinbase(), statedb, task.header)
+		receipt, err := seele.BlockChain().ApplyTransaction(tx, i+1, seele.GetCoinbase(), statedb, task.header)
 		if err != nil {
 			log.Error("apply tx failed, %s", err.Error())
 			continue


### PR DESCRIPTION
fix a bug caused by tx index in db_store.GetReceiptByTxHash.
the index of a transaction of a receipt starts from 1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seeleteam/go-seele/215)
<!-- Reviewable:end -->
