### PR TITLE
fix timestamp issue in transaction

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -371,8 +371,8 @@ func (bc *Blockchain) validateMinerRewardTx(block *types.Block) (*types.Transact
 	if err := bc.engine.ValidateRewardAmount(block.Header.Height, minerRewardTx.Data.Amount); err != nil {
 		return nil, err
 	}
-	 
-	if timestamp := minerRewardTx.Data.Timestamp; timestamp == nil || timestamp.Cmp(block.Header.CreateTimestamp) != 0 {
+	
+	if minerRewardTx.Data.Timestamp != block.Header.CreateTimestamp.Uint64() {
 	    return nil, types.ErrTimestampMismatch
 	}
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -371,6 +371,10 @@ func (bc *Blockchain) validateMinerRewardTx(block *types.Block) (*types.Transact
 	if err := bc.engine.ValidateRewardAmount(block.Header.Height, minerRewardTx.Data.Amount); err != nil {
 		return nil, err
 	}
+	 
+	if timestamp := minerRewardTx.Data.Timestamp; timestamp == nil || timestamp.Cmp(block.Header.CreateTimestamp) != 0 {
+	    return nil, types.ErrTimestampMismatch
+	}
 
 	return minerRewardTx, nil
 }

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -91,7 +91,7 @@ func newTestBlock(bc *Blockchain, parentHash common.Hash, blockHeight, txNum, st
 	common.IsShardDisabled = true
 
 	minerAccount := newTestAccount(pow.GetReward(blockHeight), 0)
-	rewardTx, _ := types.NewTransaction(common.Address{}, minerAccount.addr, minerAccount.data.Amount, big.NewInt(0), minerAccount.data.Nonce)
+	rewardTx, _ := types.NewRewardTransaction(minerAccount.addr, minerAccount.data.Amount, big.NewInt(1))
 	rewardTx.Sign(minerAccount.privKey)
 
 	txs := []*types.Transaction{rewardTx}

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -91,8 +91,7 @@ func newTestBlock(bc *Blockchain, parentHash common.Hash, blockHeight, txNum, st
 	common.IsShardDisabled = true
 
 	minerAccount := newTestAccount(pow.GetReward(blockHeight), 0)
-	rewardTx, _ := types.NewRewardTransaction(minerAccount.addr, minerAccount.data.Amount, big.NewInt(1))
-	rewardTx.Sign(minerAccount.privKey)
+	rewardTx, _ := types.NewRewardTransaction(minerAccount.addr, minerAccount.data.Amount, uint64(1))
 
 	txs := []*types.Transaction{rewardTx}
 	for i := uint64(0); i < txNum; i++ {

--- a/core/store/store_test.go
+++ b/core/store/store_test.go
@@ -87,16 +87,17 @@ func Test_blockchainDatabase_Header(t *testing.T) {
 func newTestTx() *types.Transaction {
 	tx := &types.Transaction{
 		Data: &types.TransactionData{
-			From:    *crypto.MustGenerateRandomAddress(),
-			To:      crypto.MustGenerateRandomAddress(),
-			Amount:  big.NewInt(3),
-			Fee:     big.NewInt(0),
-			Payload: make([]byte, 0),
+			From:      *crypto.MustGenerateRandomAddress(),
+			To:        crypto.MustGenerateRandomAddress(),
+			Amount:    big.NewInt(3),
+			Fee:       big.NewInt(0),
+			Timestamp: big.NewInt(0),
+			Payload:   make([]byte, 0),
 		},
 		Signature: &crypto.Signature{[]byte("test sig")},
 	}
 
-	tx.Hash = crypto.MustHash(tx)
+	tx.Hash = crypto.MustHash(tx.Data)
 
 	return tx
 }

--- a/core/store/store_test.go
+++ b/core/store/store_test.go
@@ -87,11 +87,11 @@ func Test_blockchainDatabase_Header(t *testing.T) {
 func newTestTx() *types.Transaction {
 	tx := &types.Transaction{
 		Data: &types.TransactionData{
-			From:      *crypto.MustGenerateRandomAddress(),
-			To:        crypto.MustGenerateRandomAddress(),
-			Amount:    big.NewInt(3),
-			Fee:       big.NewInt(0),
-			Payload:   make([]byte, 0),
+			From:    *crypto.MustGenerateRandomAddress(),
+			To:      crypto.MustGenerateRandomAddress(),
+			Amount:  big.NewInt(3),
+			Fee:     big.NewInt(0),
+			Payload: make([]byte, 0),
 		},
 		Signature: &crypto.Signature{[]byte("test sig")},
 	}

--- a/core/store/store_test.go
+++ b/core/store/store_test.go
@@ -91,7 +91,6 @@ func newTestTx() *types.Transaction {
 			To:        crypto.MustGenerateRandomAddress(),
 			Amount:    big.NewInt(3),
 			Fee:       big.NewInt(0),
-			Timestamp: big.NewInt(0),
 			Payload:   make([]byte, 0),
 		},
 		Signature: &crypto.Signature{[]byte("test sig")},

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -154,8 +154,8 @@ func NewRewardTransaction(miner common.Address, reward *big.Int, timestamp uint6
 	}
 	
 	rewardTxData := &TransactionData{
-	    From:      common.Address{},
-	    To:        &miner,
+	        From:      common.Address{},
+	        To:        &miner,
 		Amount:    new(big.Int).Set(reward),
 		Fee:       big.NewInt(0),
 		Timestamp: timestamp,

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -257,7 +257,7 @@ func (miner *Miner) prepareNewBlock() error {
 	if err != nil {
 		return err
 	}
-	err = miner.current.applyTransactions(miner.seele, cpyStateDB, header.Height, txs, miner.log)
+	err = miner.current.applyTransactions(miner.seele, cpyStateDB, txs, miner.log)
 	if err != nil {
 		return err
 	}

--- a/miner/task.go
+++ b/miner/task.go
@@ -54,7 +54,7 @@ func (task *Task) applyTransactions(seele SeeleBackend, statedb *state.Statedb,
 // handleMinerRewardTx handles the miner reward transaction.
 func (task *Task) handleMinerRewardTx(statedb *state.Statedb) (*big.Int, error) {
 	reward := pow.GetReward(task.header.Height)
-	rewardTx, err := types.NewRewardTransaction(task.coinbase, reward, task.header.CreateTimestamp)
+	rewardTx, err := types.NewRewardTransaction(task.coinbase, reward, task.header.CreateTimestamp.Uint64())
 	if err != nil {
 		return nil, err
 	}

--- a/miner/task.go
+++ b/miner/task.go
@@ -13,7 +13,6 @@ import (
 	"github.com/seeleteam/go-seele/core"
 	"github.com/seeleteam/go-seele/core/state"
 	"github.com/seeleteam/go-seele/core/types"
-	"github.com/seeleteam/go-seele/crypto"
 	"github.com/seeleteam/go-seele/log"
 	"github.com/seeleteam/go-seele/miner/pow"
 )
@@ -29,25 +28,18 @@ type Task struct {
 }
 
 // applyTransactions TODO need to check more about the transactions, such as gas limit
-func (task *Task) applyTransactions(seele SeeleBackend, statedb *state.Statedb, blockHeight uint64,
+func (task *Task) applyTransactions(seele SeeleBackend, statedb *state.Statedb,
 	txs map[common.Address][]*types.Transaction, log *log.SeeleLog) error {
 	// the reward tx will always be at the first of the block's transactions
-	rewardValue := pow.GetReward(blockHeight)
-	reward, err := types.NewTransaction(common.Address{}, task.coinbase, rewardValue, big.NewInt(0), 0)
+	reward, err := task.handleMinerRewardTx(statedb)
 	if err != nil {
 		return err
 	}
-	reward.Signature = &crypto.Signature{}
-	stateObj := statedb.GetOrNewStateObject(task.coinbase)
-	stateObj.AddAmount(rewardValue)
-	task.txs = append(task.txs, reward)
 
-	// add the receipt of the reward tx
-	task.receipts = append(task.receipts, types.MakeRewardReceipt(reward))
-
+    // choose transactions from the given txs
 	task.chooseTransactions(seele, statedb, txs, log)
 
-	log.Info("mining block height:%d, reward:%s, transaction number:%d", blockHeight, rewardValue, len(task.txs))
+	log.Info("mining block height:%d, reward:%s, transaction number:%d", task.header.Height, reward, len(task.txs))
 
 	root, err := statedb.Commit(nil)
 	if err != nil {
@@ -57,6 +49,25 @@ func (task *Task) applyTransactions(seele SeeleBackend, statedb *state.Statedb, 
 	task.header.StateHash = root
 
 	return nil
+}
+
+// handleMinerRewardTx handles the miner reward transaction.
+func (task *Task) handleMinerRewardTx(statedb *state.Statedb) (*big.Int, error) {
+	reward := pow.GetReward(task.header.Height)
+	rewardTx, err := types.NewRewardTransaction(task.coinbase, reward, task.header.CreateTimestamp)
+	if err != nil {
+		return nil, err
+	}
+
+	stateObj := statedb.GetOrNewStateObject(task.coinbase)
+	stateObj.AddAmount(reward)
+	
+	task.txs = append(task.txs, rewardTx)
+
+	// add the receipt of the reward tx
+	task.receipts = append(task.receipts, types.MakeRewardReceipt(rewardTx))
+
+	return reward, nil
 }
 
 func (task *Task) chooseTransactions(seele SeeleBackend, statedb *state.Statedb, txs map[common.Address][]*types.Transaction, log *log.SeeleLog) {


### PR DESCRIPTION
1. timestamp is meaningless in a common transaction, as it can be set at will. Set to 0 to filter a transaction by hash more quickly in txpool.AddTransaction(different timestamps will result in different hashes in case other fields are same)
2. as a result of the reason above, two reward txs may be of the same hash if timestamp is same. we can use the block timestamp which increases by height. so, the hashes of reward txs are different in a single chain.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seeleteam/go-seele/232)
<!-- Reviewable:end -->
