### PR TITLE
add stateless check for txs of different shard

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -188,16 +188,9 @@ func (tx *Transaction) Sign(privKey *ecdsa.PrivateKey) {
 	tx.Signature = crypto.MustSign(privKey, tx.Hash.Bytes())
 }
 
-// Validate returns true if the transaction is valid, otherwise false.
+// Validate performs a complete check for the transaction of local shard and returns nil if valid otherwise an error.
 func (tx *Transaction) Validate(statedb stateDB) error {
-	if tx.Data == nil || tx.Data.Amount == nil {
-		return ErrAmountNil
-	}
-
-	if tx.Data.Amount.Sign() < 0 {
-		return ErrAmountNegative
-	}
-
+	// verify shard
 	if fromShardNum := tx.Data.From.Shard(); fromShardNum != common.LocalShardNumber {
 		return fmt.Errorf("invalid from address, shard number is [%v], but coinbase shard number is [%v]", fromShardNum, common.LocalShardNumber)
 	}
@@ -208,12 +201,31 @@ func (tx *Transaction) Validate(statedb stateDB) error {
 		}
 	}
 
+	// verify statelessly
+	if err := tx.ValidateStatelessly(); err != nil {
+		return err
+	}
+
+	// verify state
 	if balance := statedb.GetBalance(tx.Data.From); tx.Data.Amount.Cmp(balance) > 0 {
 		return fmt.Errorf("balance is not enough, account %s, have %d, want %d", tx.Data.From.ToHex(), balance, tx.Data.Amount)
 	}
 
 	if accountNonce := statedb.GetNonce(tx.Data.From); tx.Data.AccountNonce < accountNonce {
 		return ErrNonceTooLow
+	}
+
+	return nil
+}
+
+// ValidateStatelessly performs a state independent check for the transaction and returns nil if valid otherwise an error.
+func (tx *Transaction) ValidateStatelessly() error {
+	if tx.Data == nil || tx.Data.Amount == nil {
+		return ErrAmountNil
+	}
+
+	if tx.Data.Amount.Sign() < 0 {
+		return ErrAmountNegative
 	}
 
 	if err := validatePayload(tx.Data.To, tx.Data.Payload); err != nil {

--- a/seele/api_public.go
+++ b/seele/api_public.go
@@ -86,7 +86,9 @@ func (api *PublicSeeleAPI) AddTx(tx *types.Transaction, result *bool) error {
 	shard := tx.Data.From.Shard()
 	var err error
 	if shard != common.LocalShardNumber {
-		api.s.seeleProtocol.SendDifferentShardTx(tx, shard)
+	        if err = tx.ValidateStatelessly(); err == nil {
+			api.s.seeleProtocol.SendDifferentShardTx(tx, shard)
+		}
 	} else {
 		err = api.s.txPool.AddTransaction(tx)
 	}


### PR DESCRIPTION
when a tx with different shard number is sent to a node from client, a state independent check should be performed before sending it to corresponding peer sets for network performance

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seeleteam/go-seele/260)
<!-- Reviewable:end -->
