### PR TITLE
add shard check in WriteBlock and handleMsg

### DIFF
--- a/cmd/util/generate_key_pair.go
+++ b/cmd/util/generate_key_pair.go
@@ -27,8 +27,8 @@ func GetGenerateKeyPairCmd(name string) (cmds *cobra.Command) {
 			var publicKey *common.Address
 			var privateKey *ecdsa.PrivateKey
 			var err error
-			if *shard > common.ShardNumber {
-				fmt.Printf("not supported shard number, shard number should be [0, %d]\n", common.ShardNumber)
+			if *shard > common.ShardCount {
+				fmt.Printf("not supported shard number, shard number should be [0, %d]\n", common.ShardCount)
 				return
 			} else if *shard == 0 {
 				publicKey, privateKey, err = crypto.GenerateKeyPair()

--- a/common/Address.go
+++ b/common/Address.go
@@ -168,7 +168,7 @@ func (id Address) Shard() uint {
 	tail := uint(binary.BigEndian.Uint16(id[18:]))
 	sum += (tail >> 4)
 
-	return (sum % ShardNumber) + 1
+	return (sum % ShardCount) + 1
 }
 
 // CreateContractAddress returns a contract address that in the same shard of this address.
@@ -184,13 +184,13 @@ func (id Address) CreateContractAddress(nonce uint64, hashFunc func(interface{})
 	}
 
 	// sum [18:20] for shard mod and contract address type
-	shardNum := (sum % ShardNumber) + 1
+	shardNum := (sum % ShardCount) + 1
 	encoded := make([]byte, 2)
 	var mod uint
 	if shardNum <= targetShardNum {
 		mod = targetShardNum - shardNum
 	} else {
-		mod = ShardNumber + targetShardNum - shardNum
+		mod = ShardCount + targetShardNum - shardNum
 	}
 	mod <<= 4
 	mod |= uint(AddressTypeContract) // set address type in the last 4 bits

--- a/common/constant.go
+++ b/common/constant.go
@@ -13,7 +13,8 @@ import (
 	"github.com/seeleteam/go-seele/log/comm"
 )
 
-const ShardNumber = 20
+//ShardCount represents the total number of shards.
+const ShardCount = 20
 
 var (
 	// tempFolder used to store temp file, such as log files

--- a/common/shard.go
+++ b/common/shard.go
@@ -14,5 +14,5 @@ var LocalShardNumber uint
 
 // IsShardEnabled returns true if the LocalShardNumber is set. Otherwise, false.
 func IsShardEnabled() bool {
-	return LocalShardNumber > UndefinedShardNumber && LocalShardNumber <= ShardNumber
+	return LocalShardNumber > UndefinedShardNumber && LocalShardNumber <= ShardCount
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -8,6 +8,7 @@ package core
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"math/big"
 	"sync"
 	"time"
@@ -284,6 +285,12 @@ func (bc *Blockchain) WriteBlock(block *types.Block) error {
 }
 
 func (bc *Blockchain) validateBlock(block, preBlock *types.Block) error {
+	if common.IsShardEnabled() {
+		if shard := block.GetShardNumber(); shard != common.LocalShardNumber {
+			return fmt.Errorf("invalid shard number. block shard number is [%v], but local shard number is [%v]", shard, common.LocalShardNumber)
+		}
+	}
+
 	if len(block.Transactions) > BlockTransactionNumberLimit {
 		return ErrBlockTooManyTxs
 	}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -85,7 +85,7 @@ func GetGenesis(info GenesisInfo) *Genesis {
 	}
 }
 
-// GetShardNumber get shard number of genesis
+// GetShardNumber gets the shard number of genesis
 func (genesis *Genesis) GetShardNumber() uint {
 	return genesis.info.ShardNumber
 }
@@ -115,7 +115,7 @@ func (genesis *Genesis) InitializeAndValidate(bcStore store.BlockchainStore, acc
 	}
 
 	if data.ShardNumber != genesis.info.ShardNumber {
-		return errors.New("specific shard is not matched with shard number in genesis info")
+		return errors.New("specific shard number does not match with the shard number in genesis info")
 	}
 
 	headerHash := genesis.header.Hash()

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -98,3 +98,12 @@ func (block *Block) FindTransaction(txHash common.Hash) *Transaction {
 
 	return nil
 }
+
+// GetShardNumber returns the shard number of the block, which means the shard number of the creator.
+func (block *Block) GetShardNumber() uint {
+	if block.Header == nil {
+		return common.UndefinedShardNumber
+	}
+
+	return block.Header.Creator.Shard()
+}

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -153,8 +153,8 @@ func MustGenerateShardAddress(shardNum uint) *common.Address {
 }
 
 func MustGenerateShardKeyPair(shard uint) (*common.Address, *ecdsa.PrivateKey) {
-	if shard == 0 || shard > common.ShardNumber {
-		panic(fmt.Errorf("invalid shard number, should be between 1 and %v", common.ShardNumber))
+	if shard == 0 || shard > common.ShardCount {
+		panic(fmt.Errorf("invalid shard number, should be between 1 and %v", common.ShardCount))
 	}
 
 	for i := 1; ; i++ {

--- a/node/node.go
+++ b/node/node.go
@@ -93,11 +93,11 @@ func (n *Node) Start() error {
 	specificShard := n.config.SeeleConfig.GenesisConfig.ShardNumber
 	if specificShard == 0 {
 		// select a shard randomly
-		specificShard = uint(rand.Intn(common.ShardNumber) + 1)
+		specificShard = uint(rand.Intn(common.ShardCount) + 1)
 	}
 
-	if specificShard > common.ShardNumber {
-		return fmt.Errorf("unsupported shard number, it must in range [0, %d]", common.ShardNumber)
+	if specificShard > common.ShardCount {
+		return fmt.Errorf("unsupported shard number, it must be in range [0, %d]", common.ShardCount)
 	}
 
 	common.LocalShardNumber = specificShard
@@ -108,7 +108,7 @@ func (n *Node) Start() error {
 		n.log.Info("coinbase is %s", n.config.SeeleConfig.Coinbase.ToHex())
 
 		if coinbaseShard != specificShard {
-			return fmt.Errorf("coinbase is not matched with specific shard number, "+
+			return fmt.Errorf("coinbase does not match with specific shard number, "+
 				"coinbase shard:%d, specific shard number:%d", coinbaseShard, specificShard)
 		}
 	}

--- a/p2p/discovery/table.go
+++ b/p2p/discovery/table.go
@@ -19,12 +19,12 @@ const (
 	hashBits             = len(common.Hash{}) * 8
 	nBuckets             = hashBits + 1 // Number of buckets
 	shardTargeNodeNumber = 1            // other shard minimal node number for start
-	UndefinedShardNumber = 0            // shard number indicate its shard is undefined
+	UndefinedShardNumber = 0            // UndefinedShardNumber indicates the shard number is undefined
 )
 
 type Table struct {
 	buckets      [nBuckets]*bucket
-	shardBuckets [common.ShardNumber + 1]*bucket // 0 represents undefined shard number node.
+	shardBuckets [common.ShardCount + 1]*bucket // 0 represents undefined shard number node.
 	selfNode     *Node                           //info of local node
 
 	log *log.SeeleLog
@@ -42,7 +42,7 @@ func newTable(id common.Address, addr *net.UDPAddr, shard uint, log *log.SeeleLo
 		table.buckets[i] = newBuckets(log)
 	}
 
-	for i := 0; i < common.ShardNumber+1; i++ {
+	for i := 0; i < common.ShardCount+1; i++ {
 		table.shardBuckets[i] = newBuckets(log)
 	}
 

--- a/p2p/discovery/udp.go
+++ b/p2p/discovery/udp.go
@@ -347,7 +347,7 @@ func (u *udp) discovery(isFast bool) {
 			time.Sleep(discoveryInterval)
 		}
 
-		for i := 1; i < common.ShardNumber+1; i++ {
+		for i := 1; i < common.ShardCount+1; i++ {
 			shardBucket := u.table.shardBuckets[i]
 			size := shardBucket.size()
 			if size < bucketSize {
@@ -378,7 +378,7 @@ func (u *udp) discovery(isFast bool) {
 
 		if isFast {
 			enough := true
-			for i := 1; i < common.ShardNumber+1; i++ {
+			for i := 1; i < common.ShardCount+1; i++ {
 				if uint(i) == u.self.Shard {
 					continue
 				}

--- a/p2p/peer_set.go
+++ b/p2p/peer_set.go
@@ -20,7 +20,7 @@ type peerSet struct {
 
 func NewPeerSet() *peerSet {
 	peers := make(map[uint]map[common.Address]*Peer)
-	for i := 1; i < common.ShardNumber+1; i++ {
+	for i := 1; i < common.ShardCount+1; i++ {
 		peers[uint(i)] = make(map[common.Address]*Peer)
 	}
 

--- a/seele/peer_set.go
+++ b/seele/peer_set.go
@@ -14,7 +14,7 @@ import (
 
 type peerSet struct {
 	peerMap    map[common.Address]*peer
-	shardPeers [1 + common.ShardNumber]map[common.Address]*peer
+	shardPeers [1 + common.ShardCount]map[common.Address]*peer
 	lock       sync.RWMutex
 }
 
@@ -24,7 +24,7 @@ func newPeerSet() *peerSet {
 		lock:    sync.RWMutex{},
 	}
 
-	for i := 0; i < 1+common.ShardNumber; i++ {
+	for i := 0; i < 1+common.ShardCount; i++ {
 		ps.shardPeers[i] = make(map[common.Address]*peer)
 	}
 

--- a/seele/seeleprotocol.go
+++ b/seele/seeleprotocol.go
@@ -456,8 +456,11 @@ handler:
 			}
 
 			p.log.Debug("got block msg height:%d, hash:%s", block.Header.Height, block.HeaderHash.ToHex())
-			// @todo need to make sure WriteBlock handle block fork
-			p.chain.WriteBlock(&block)
+
+			if block.GetShardNumber() == common.LocalShardNumber {
+				// @todo need to make sure WriteBlock handle block fork
+				p.chain.WriteBlock(&block)
+			}
 
 		case downloader.GetBlockHeadersMsg:
 			var query blockHeadersQuery


### PR DESCRIPTION

1. blockchain.WriteBlock: a shard check is necessary to make sure that target block(creator of the block) has the same shard number as the genesis block(local shard) when a block is written into blockchain.

2. seeleprotocol.handleMsg: when a block received,  add an instant shard check for it.

3. common.constant: rename ShardNumber to ShardCount. The former means the shard number and is confused with LocalShardNumber while the latter means total number of shards.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seeleteam/go-seele/278)
<!-- Reviewable:end -->
