### PR TITLE
Fix Bug 1000607: improve the commit perf of statedb

### DIFF
--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -119,7 +119,7 @@ func newTestBlock(bc *Blockchain, parentHash common.Hash, blockHeight, txNum, st
 			panic(err)
 		}
 
-		if stateRootHash, err = statedb.Commit(nil); err != nil {
+		if stateRootHash, err = statedb.Hash(); err != nil {
 			panic(err)
 		}
 

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -401,3 +401,17 @@ func Benchmark_Blockchain_WriteBlock(b *testing.B) {
 		preBlock = block
 	}
 }
+
+func Benchmark_Blockchain_ValidateTxs(b *testing.B) {
+	db, dispose := leveldb.NewTestDatabase()
+	defer dispose()
+
+	bc := newTestBlockchain(db)
+	preBlock := bc.genesisBlock
+	block := newTestBlock(bc, preBlock.HeaderHash, preBlock.Header.Height+1, BlockTransactionNumberLimit-1, 0)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		types.BatchValidateTxs(block.Transactions[1:])
+	}
+}

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -383,18 +383,6 @@ func Test_Blockchain_ApplyTransaction(t *testing.T) {
 	assert.Equal(t, statedb.GetBalance(coinbase), big.NewInt(52))
 }
 
-func Benchmark_NewTestBlock(b *testing.B) {
-	db, dispose := leveldb.NewTestDatabase()
-	defer dispose()
-
-	bc := newTestBlockchain(db)
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		newTestBlock(bc, bc.genesisBlock.HeaderHash, bc.genesisBlock.Header.Height+1, BlockTransactionNumberLimit-1, 0)
-	}
-}
-
 func Benchmark_Blockchain_WriteBlock(b *testing.B) {
 	db, dispose := leveldb.NewTestDatabase()
 	defer dispose()
@@ -404,7 +392,9 @@ func Benchmark_Blockchain_WriteBlock(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		b.StopTimer()
 		block := newTestBlock(bc, preBlock.HeaderHash, preBlock.Header.Height+1, BlockTransactionNumberLimit-1, 0)
+		b.StartTimer()
 		if err := bc.WriteBlock(block); err != nil {
 			b.Fatalf("failed to write block, %v", err.Error())
 		}

--- a/core/evm.go
+++ b/core/evm.go
@@ -102,6 +102,10 @@ func ProcessContract(context *vm.Context, tx *types.Transaction, txIndex int, st
 		return nil, vm.ErrInsufficientBalance
 	}
 
+	// transfer fee to coinbase
+	statedb.SubBalance(tx.Data.From, totalFee)
+	statedb.AddBalance(context.Coinbase, totalFee)
+
 	if err != nil {
 		receipt.Failed = true
 		receipt.Result = []byte(err.Error())
@@ -109,7 +113,7 @@ func ProcessContract(context *vm.Context, tx *types.Transaction, txIndex int, st
 
 	receipt.UsedGas = gas - leftOverGas
 
-	if receipt.PostState, err = statedb.Commit(nil); err != nil {
+	if receipt.PostState, err = statedb.Hash(); err != nil {
 		return nil, err
 	}
 
@@ -117,10 +121,6 @@ func ProcessContract(context *vm.Context, tx *types.Transaction, txIndex int, st
 	if receipt.Logs == nil {
 		receipt.Logs = make([]*types.Log, 0)
 	}
-
-	// transfer fee to coinbase
-	statedb.SubBalance(tx.Data.From, totalFee)
-	statedb.AddBalance(context.Coinbase, totalFee)
 
 	return receipt, nil
 }

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -62,7 +62,7 @@ func GetGenesis(info GenesisInfo) *Genesis {
 		panic(err)
 	}
 
-	stateRootHash, err := statedb.Commit(nil)
+	stateRootHash, err := statedb.Hash()
 	if err != nil {
 		panic(err)
 	}
@@ -150,9 +150,8 @@ func getStateDB(info GenesisInfo) (*state.Statedb, error) {
 
 	for addr, amount := range info.Accounts {
 		if !common.IsShardEnabled() || addr.Shard() == info.ShardNumber {
-			stateObj := statedb.GetOrNewStateObject(addr)
-			stateObj.SetNonce(0)
-			stateObj.SetAmount(amount)
+			statedb.CreateAccount(addr)
+			statedb.SetBalance(addr, amount)
 		}
 	}
 

--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -13,14 +13,25 @@ import (
 
 type journalEntry interface {
 	revert(*Statedb)
+	dirtied() *common.Address
 }
 
 type journal struct {
 	entries []journalEntry
+	dirties map[common.Address]uint
+}
+
+func newJournal() *journal {
+	return &journal{
+		dirties: make(map[common.Address]uint),
+	}
 }
 
 func (j *journal) append(entry journalEntry) {
 	j.entries = append(j.entries, entry)
+	if addr := entry.dirtied(); addr != nil {
+		j.dirties[*addr]++
+	}
 }
 
 func (j *journal) snapshot() int {
@@ -30,6 +41,13 @@ func (j *journal) snapshot() int {
 func (j *journal) revert(statedb *Statedb, snapshot int) {
 	for i := len(j.entries) - 1; i >= snapshot; i-- {
 		j.entries[i].revert(statedb)
+
+		if addr := j.entries[i].dirtied(); addr != nil {
+			if j.dirties[*addr]--; j.dirties[*addr] == 0 {
+				delete(j.dirties, *addr)
+			}
+		}
+
 		j.entries[i] = nil
 	}
 
@@ -71,20 +89,40 @@ func (ch refundChange) revert(s *Statedb) {
 	s.refund = ch.prev
 }
 
+func (ch refundChange) dirtied() *common.Address {
+	return nil
+}
+
 func (ch storageChange) revert(s *Statedb) {
 	s.getStateObject(*ch.account).setState(ch.key, ch.prev)
+}
+
+func (ch storageChange) dirtied() *common.Address {
+	return ch.account
 }
 
 func (ch balanceChange) revert(s *Statedb) {
 	s.getStateObject(*ch.account).account.Amount = ch.prev
 }
 
+func (ch balanceChange) dirtied() *common.Address {
+	return ch.account
+}
+
 func (ch codeChange) revert(s *Statedb) {
 	s.getStateObject(*ch.account).setCode(ch.prev)
 }
 
+func (ch codeChange) dirtied() *common.Address {
+	return ch.account
+}
+
 func (ch nonceChange) revert(s *Statedb) {
 	s.getStateObject(*ch.account).account.Nonce = ch.prev
+}
+
+func (ch nonceChange) dirtied() *common.Address {
+	return ch.account
 }
 
 func (ch suicideChange) revert(s *Statedb) {
@@ -95,6 +133,14 @@ func (ch suicideChange) revert(s *Statedb) {
 	}
 }
 
+func (ch suicideChange) dirtied() *common.Address {
+	return ch.account
+}
+
 func (ch createObjectChange) revert(s *Statedb) {
 	delete(s.stateObjects, *ch.account)
+}
+
+func (ch createObjectChange) dirtied() *common.Address {
+	return ch.account
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -35,7 +35,7 @@ type Statedb struct {
 	curLogs    []*types.Log
 
 	// State modifications for current processed tx.
-	curJournal journal
+	curJournal *journal
 }
 
 // NewStatedb constructs and returns a statedb instance
@@ -49,7 +49,7 @@ func NewStatedb(root common.Hash, db database.Database) (*Statedb, error) {
 		db:           db,
 		trie:         trie,
 		stateObjects: make(map[common.Address]*StateObject),
-		curJournal:   journal{},
+		curJournal:   newJournal(),
 	}, nil
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -154,6 +154,8 @@ func (s *Statedb) Hash() (common.Hash, error) {
 		}
 	}
 
+	s.clearJournalAndRefund()
+
 	return s.trie.Hash(), nil
 }
 
@@ -217,6 +219,11 @@ func (s *Statedb) Prepare(txIndex int) {
 	s.curTxIndex = uint(txIndex)
 	s.curLogs = nil
 
+	s.clearJournalAndRefund()
+}
+
+func (s *Statedb) clearJournalAndRefund() {
+	s.refund = 0
 	s.curJournal.entries = s.curJournal.entries[:0]
 	s.curJournal.dirties = make(map[common.Address]uint)
 }

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -149,7 +149,7 @@ func Test_Commit_AccountStorages(t *testing.T) {
 	statedb.SetState(addr, common.StringToHash("test key"), common.StringToHash("test value"))
 
 	// Get root hash for receipt PostState
-	root1, err := statedb.Commit(nil)
+	root1, err := statedb.Hash()
 	assert.Equal(t, err, nil)
 
 	// Commit to DB
@@ -188,7 +188,7 @@ func Test_StateDB_CommitMultipleChanges(t *testing.T) {
 		statedb.SetCode(addr, []byte("hello"))
 		statedb.SetState(addr, common.StringToHash("key"), common.StringToHash("value"))
 
-		if _, err = statedb.Commit(nil); err != nil {
+		if _, err = statedb.Hash(); err != nil {
 			panic(err)
 		}
 
@@ -245,14 +245,14 @@ func Benchmark_Trie_Hash(b *testing.B) {
 		statedb.SetCode(addr, []byte("hello"))
 		statedb.SetState(addr, common.StringToHash("key"), common.StringToHash("value"))
 
-		if _, err := statedb.Commit(nil); err != nil {
+		if _, err := statedb.Hash(); err != nil {
 			panic(err)
 		}
 	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if _, err := statedb.Commit(nil); err != nil {
+		if _, err := statedb.Hash(); err != nil {
 			panic(err)
 		}
 	}

--- a/miner/task.go
+++ b/miner/task.go
@@ -41,7 +41,7 @@ func (task *Task) applyTransactions(seele SeeleBackend, statedb *state.Statedb,
 
 	log.Info("mining block height:%d, reward:%s, transaction number:%d", task.header.Height, reward, len(task.txs))
 
-	root, err := statedb.Commit(nil)
+	root, err := statedb.Hash()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
See detailed benchmarks as below:
[Before Fix]
Benchmark_Blockchain_WriteBlock-8   	    1	1861310400 ns/op	714929216 B/op	14077467 allocs/op
[After Fix]
Benchmark_Blockchain_WriteBlock-8   	    1	1140321600 ns/op	318786264 B/op	 1645318 allocs/op
[Validate txs signatures]
Benchmark_Blockchain_ValidateTxs-8   	    2	 782407700 ns/op	19611852 B/op	  210103 allocs/op