### PR TITLE
fix a typo error in rpc api getengineinfo

### DIFF
--- a/cmd/client/cmd/root.go
+++ b/cmd/client/cmd/root.go
@@ -283,7 +283,7 @@ func AddCommands(app *cli.App, isFullNode bool) {
 				Name:   "getengineinfo",
 				Usage:  "get miner engine information",
 				Flags:  rpcFlags(),
-				Action: rpcAction("miner", "GetEngineInfo"),
+				Action: rpcAction("miner", "getEngineInfo"),
 			},
 			{
 				Name:   "setthreads",


### PR DESCRIPTION
rpc miner_getEngineInfo can't be called

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seeleteam/go-seele/657)
<!-- Reviewable:end -->
