### PR TITLE
api:add  IsListening api

### DIFF
--- a/api/api_network.go
+++ b/api/api_network.go
@@ -41,3 +41,6 @@ func (n *PrivateNetworkAPI) GetNetworkID() (string, error) {
 func (n *PrivateNetworkAPI) GetProtocolVersion() (uint, error) {
 	return n.s.ProtocolBackend().GetProtocolVersion()
 }
+
+// Always listening
+func (n *PrivateNetworkAPI) IsListening() bool { return true }


### PR DESCRIPTION
It will make sure the node started that we can call the seele node's IsListening API when connect to seele node. 