### PR TITLE
light node only support to get block by hash from full node.

### DIFF
--- a/light/lightBackend.go
+++ b/light/lightBackend.go
@@ -53,9 +53,14 @@ func (l *LightBackend) GetBlock(hash common.Hash, height int64) (*types.Block, e
 
 	if hash.IsEmpty() {
 		if height < 0 {
-			request.Height = l.ChainBackend().CurrentHeader().Height
+			request.Hash = l.ChainBackend().CurrentHeader().Hash()
 		} else {
-			request.Height = uint64(height)
+			hash, err := l.ChainBackend().GetStore().GetBlockHash(uint64(height))
+			if err != nil {
+				return nil, err
+			}
+
+			request.Hash = hash
 		}
 	}
 

--- a/light/odr_block.go
+++ b/light/odr_block.go
@@ -13,9 +13,8 @@ import (
 
 type odrBlock struct {
 	OdrItem
-	Hash   common.Hash  // Retrieved block hash
-	Height uint64       // Retrieved block height
-	Block  *types.Block `rlp:"nil"` // Retrieved block
+	Hash  common.Hash  // Retrieved block hash
+	Block *types.Block `rlp:"nil"` // Retrieved block
 }
 
 func (odr *odrBlock) code() uint16 {
@@ -25,12 +24,7 @@ func (odr *odrBlock) code() uint16 {
 func (odr *odrBlock) handle(lp *LightProtocol) (uint16, odrResponse) {
 	var err error
 
-	if odr.Hash.IsEmpty() {
-		if odr.Block, err = lp.chain.GetStore().GetBlockByHeight(odr.Height); err != nil {
-			lp.log.Debug("Failed to get block, height = %d, error = %v", odr.Height, err)
-			odr.Error = err.Error()
-		}
-	} else if odr.Block, err = lp.chain.GetStore().GetBlock(odr.Hash); err != nil {
+	if odr.Block, err = lp.chain.GetStore().GetBlock(odr.Hash); err != nil {
 		lp.log.Debug("Failed to get block, hash = %v, error = %v", odr.Hash, err)
 		odr.Error = err.Error()
 	}
@@ -43,20 +37,11 @@ func (odr *odrBlock) validate(request odrRequest, bcStore store.BlockchainStore)
 		return nil
 	}
 
-	var err error
-
-	if err = odr.Block.Validate(); err != nil {
+	if err := odr.Block.Validate(); err != nil {
 		return err
 	}
 
-	hash := request.(*odrBlock).Hash
-	if hash.IsEmpty() {
-		if hash, err = bcStore.GetBlockHash(odr.Height); err != nil {
-			return err
-		}
-	}
-
-	if !hash.Equal(odr.Block.HeaderHash) {
+	if hash := request.(*odrBlock).Hash; !hash.Equal(odr.Block.HeaderHash) {
 		return types.ErrBlockHashMismatch
 	}
 

--- a/light/odr_block_test.go
+++ b/light/odr_block_test.go
@@ -34,7 +34,7 @@ func Test_OdrBlock_Handle(t *testing.T) {
 	code, resp := ob1.handle(lp)
 	assert.Equal(t, code, blockResponseCode)
 	assert.NotNil(t, resp)
-	assert.Nil(t, resp.getError())
+	assert.NotNil(t, resp.getError())
 	assert.Equal(t, resp.getRequestID(), uint32(1))
 
 	// case 2: invalid block hash
@@ -80,7 +80,6 @@ func newTestOdrBlock(hash common.Hash) *odrBlock {
 	return &odrBlock{
 		OdrItem: newTestOdrItem(),
 		Hash:    hash,
-		Height:  1,
 	}
 }
 
@@ -88,7 +87,6 @@ func newTestOdrBlockWithBlock(hash common.Hash) *odrBlock {
 	return &odrBlock{
 		OdrItem: newTestOdrItem(),
 		Hash:    hash,
-		Height:  1,
 		Block:   newTestBlock(),
 	}
 }


### PR DESCRIPTION
If light node query block by height from full node, the block may not found in case of chain forking.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seeleteam/go-seele/726)
<!-- Reviewable:end -->
