### PR TITLE
add another getMiningTarget function

### DIFF
--- a/consensus/pow/engine.go
+++ b/consensus/pow/engine.go
@@ -151,13 +151,13 @@ func getMiningTarget(difficulty *big.Int) *big.Int {
 
 func getSecondMiningTarget(time uint64, parentHeader *types.BlockHeader) *big.Int {
     // target = maxUint256 / current difficulty
-    // current difficulty = 20,000,000 / min((current time - parentTime) / 20, 100)
+    // current difficulty = 20,000,000 / min((current time - parentTime) / 20 + 1, 100)
 
     parentTime := parentHeader.CreateTimestamp.Uint64()
 
     // the difficulty should be high at the beginning
     maxDifficulty := big.NewInt(20000000)
-    interval := (time - parentTime) / 20
+    interval := ((time - parentTime)  / 20 + 1)
     x := big.NewInt(int64(interval))
     big100 := big.NewInt(100)
 

--- a/consensus/pow/engine.go
+++ b/consensus/pow/engine.go
@@ -144,3 +144,28 @@ func verifyTarget(header *types.BlockHeader) error {
 func getMiningTarget(difficulty *big.Int) *big.Int {
 	return new(big.Int).Div(maxUint256, difficulty)
 }
+
+// returns the second mining target based on the difference of current clock time
+// and the timestamp of parent block. Initially, the difficulty should be high
+// This function is used to determine which coinbase can mine.
+
+func getSecondMiningTarget(time uint64, parentHeader *types.BlockHeader) *big.Int {
+    // target = maxUint256 / current difficulty
+    // current difficulty = 20,000,000 / min((current time - parentTime) / 20, 100)
+
+    parentTime := parentHeader.CreateTimestamp.Uint64()
+
+    // the difficulty should be high at the beginning
+    maxDifficulty := big.NewInt(20000000)
+    interval := (time - parentTime) / 20
+    x := big.NewInt(int64(interval))
+    big100 := big.NewInt(100)
+
+    if x.Cmp(big100) > 0 {
+        x = big100
+    }
+    var currDifficulty = big.NewInt(0)
+    currDifficulty.Div(maxDifficulty, x)
+
+    return new(big.Int).Div(maxUint256, currDifficulty)
+}


### PR DESCRIPTION
It's used after the miner has found the nonce such that sha256(blockheaderhash + nonce) < firstMiningTarget. The mined block will not be broadcasted unless sha256(nonce + coinbase) < secondMiningTarget.