### PR TITLE
add hash comparison to reduce forks

### DIFF
--- a/consensus/pow/engine.go
+++ b/consensus/pow/engine.go
@@ -151,13 +151,13 @@ func getMiningTarget(difficulty *big.Int) *big.Int {
 
 func getSecondMiningTarget(time uint64, parentHeader *types.BlockHeader) *big.Int {
     // target = maxUint256 / current difficulty
-    // current difficulty = 20,000,000 / min((current time - parentTime) / 20, 100)
+    // current difficulty = 20,000,000 / min((current time - parentTime) / 20 + 1, 100)
 
     parentTime := parentHeader.CreateTimestamp.Uint64()
 
     // the difficulty should be high at the beginning
     maxDifficulty := big.NewInt(20000000)
-    interval := (time - parentTime) / 20
+    interval := ((time - parentTime)  / 20 + 1)
     x := big.NewInt(int64(interval))
     big100 := big.NewInt(100)
 

--- a/consensus/pow/engine.go
+++ b/consensus/pow/engine.go
@@ -144,3 +144,28 @@ func verifyTarget(header *types.BlockHeader) error {
 func getMiningTarget(difficulty *big.Int) *big.Int {
 	return new(big.Int).Div(maxUint256, difficulty)
 }
+
+// returns the second mining target based on the difference of current clock time
+// and the timestamp of parent block. Initially, the difficulty should be high
+// This function is used to determine which coinbase can mine.
+
+func getSecondMiningTarget(time uint64, parentHeader *types.BlockHeader) *big.Int {
+    // target = maxUint256 / current difficulty
+    // current difficulty = 20,000,000 / min((current time - parentTime) / 20, 100)
+
+    parentTime := parentHeader.CreateTimestamp.Uint64()
+
+    // the difficulty should be high at the beginning
+    maxDifficulty := big.NewInt(20000000)
+    interval := (time - parentTime) / 20
+    x := big.NewInt(int64(interval))
+    big100 := big.NewInt(100)
+
+    if x.Cmp(big100) > 0 {
+        x = big100
+    }
+    var currDifficulty = big.NewInt(0)
+    currDifficulty.Div(maxDifficulty, x)
+
+    return new(big.Int).Div(maxUint256, currDifficulty)
+}

--- a/light/peer_set.go
+++ b/light/peer_set.go
@@ -47,14 +47,16 @@ func (p *peerSet) getPeers() map[common.Address]*peer {
 func (p *peerSet) bestPeer() *peer {
 	var (
 		bestPeer *peer
+		bestHash common.Hash
 		bestTd   *big.Int
 	)
 
 	v := p.getPeers()
 	for _, pe := range v {
-		if _, td := pe.Head(); bestPeer == nil || td.Cmp(bestTd) > 0 {
+		// if the total difficulties of the peers are the same, compare their head hashes
+		if hash, td := pe.Head(); bestPeer == nil || td.Cmp(bestTd) > 0 || (td.Cmp(bestTd) == 0 && hash.Big().Cmp(bestHash.Big()) > 0) {
 			if !pe.isSyncing() {
-				bestPeer, bestTd = pe, td
+				bestPeer, bestTd, bestHash = pe, td, hash
 			}
 		}
 	}

--- a/seele/peer_set.go
+++ b/seele/peer_set.go
@@ -33,12 +33,14 @@ func newPeerSet() *peerSet {
 
 func (p *peerSet) bestPeer(shard uint) *peer {
 	var bestPeer *peer
-	bestTd := big.NewInt(0)
+	var bestHash common.Hash
+	bestTd := big.NewInt(0)	
 
 	peers := p.getPeerByShard(shard)
 	for _, peer := range peers {
-		if _, td := peer.Head(); bestPeer == nil || td.Cmp(bestTd) > 0 {
-			bestPeer, bestTd = peer, td
+		// if the total difficulties of the peers are the same, compare their head hashes
+		if hash, td := peer.Head(); bestPeer == nil || td.Cmp(bestTd) > 0 || (td.Cmp(bestTd) == 0 && hash.Big().Cmp(bestHash.Big()) > 0) {
+			bestPeer, bestTd, bestHash = peer, td, hash
 		}
 	}
 


### PR DESCRIPTION
It is used to reduce forks. When the total difficulties of two peers are the same, select the one with larger hash (compared as an integer). 