### PR TITLE
Multiply Threads & BatchUp Validate Debts

### DIFF
--- a/core/concurrent_debt_map.go
+++ b/core/concurrent_debt_map.go
@@ -6,6 +6,7 @@
 package core
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/seeleteam/go-seele/common"
@@ -43,11 +44,20 @@ func (m *ConcurrentDebtMap) remove(hash common.Hash) {
 	delete(m.value, hash)
 }
 
+func (m *ConcurrentDebtMap) removeByValue(debt *types.Debt) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	delete(m.value, debt.Hash)
+}
+
 func (m *ConcurrentDebtMap) add(debt *types.Debt) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
 	if len(m.value) >= m.capacity && m.value[debt.Hash] == nil {
+		//for test zlk
+		fmt.Println("confirmed debtpool len:", len(m.value))
 		return errDebtFull
 	}
 

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/seeleteam/go-seele/common"
@@ -381,6 +382,11 @@ func BatchValidateTxs(txs []*Transaction) error {
 }
 
 func BatchValidate(handler func(index int) error, len int) error {
+	//test zlk
+
+	t_batchvalidate := time.Now()
+	fmt.Println(t_batchvalidate)
+
 	threads := runtime.NumCPU() / 2 // in case of CPU 100%
 
 	// single thread for few CPU kernel or few txs to validate.
@@ -403,20 +409,22 @@ func BatchValidate(handler func(index int) error, len int) error {
 		wg.Add(1)
 		go func(offset int) {
 			defer wg.Done()
-
 			for j := offset; j < len && atomic.LoadUint32(&hasErr) == 0; j += threads {
 				if e := handler(j); e != nil {
 					if atomic.CompareAndSwapUint32(&hasErr, 0, 1) {
 						err = e
 					}
-
 					break
 				}
 			}
 		}(i)
 	}
-
 	wg.Wait()
+
+	//test zlk
+	fmt.Printf("len: %d batch validate time is:", len)
+	t_batch_end := time.Now()
+	fmt.Println(t_batch_end.Sub(t_batchvalidate))
 
 	return err
 }


### PR DESCRIPTION
* use multiply threads instead of signle thread to validate debts in order to speed up validation

* add removeByValue function

* add BatchUp toConfimedDebts function

* add DoBatchCheckingDebtHandler function and change loopCheckingDebt DoCheckingDebt to DoBatchCheckingDebt

* add BatchUp, BatchValidateDebts, singleValidate functions in lightclient.go (so far,not in use)

* add some printf in order to see test result