### PR TITLE
Skip the determinant of the first submatrix in MPoW

### DIFF
--- a/consensus/spow/engine.go
+++ b/consensus/spow/engine.go
@@ -663,7 +663,7 @@ func calDetmLoop(matrix *mat.Dense, dim int, log *log.SeeleLog) (float64, int) {
 				return det, nonZerosCount
 			}
 			// at this point, even all left are ok, the total is still smaller than target, just stop!
-			if nonZerosCount+(256-i) < nonZeroCountTarget {
+			if nonZerosCount+(256-i-dim) < nonZeroCountTarget {
 				return det, nonZerosCount
 			}
 		}

--- a/consensus/spow/engine.go
+++ b/consensus/spow/engine.go
@@ -644,28 +644,24 @@ func calDetmLoop(matrix *mat.Dense, dim int, log *log.SeeleLog) (float64, int) {
 	var nonZerosCount = int(0)
 	nonZeroCountTarget := getNonZeroCountTarget(dim)
 	submatrix := mat.NewDense(dim, dim, nil)
-	for i := 0; i < 256-dim; i++ {
+	for i := 1; i < 256-dim; i++ {
 		submatrix = submatCopy(matrix, i, dim)
 
 		det := mat.Det(submatrix)
-		// return first det
-		if i == 0 {
-			ret = det
-		} else {
-			// check number of det whose det is larger than 0
-			detInt := int64(det)
-			detBig := big.NewInt(detInt)
-			if detBig.Cmp(big.NewInt(0)) > 0 {
-				nonZerosCount++
-			}
-			// already meet the requirement, just stop and return
-			if nonZerosCount >= nonZeroCountTarget {
-				return det, nonZerosCount
-			}
-			// at this point, even all left are ok, the total is still smaller than target, just stop!
-			if nonZerosCount+(256-i-dim) < nonZeroCountTarget {
-				return det, nonZerosCount
-			}
+
+		// check number of det whose det is larger than 0
+		detInt := int64(det)
+		detBig := big.NewInt(detInt)
+		if detBig.Cmp(big.NewInt(0)) > 0 {
+			nonZerosCount++
+		}
+		// already meet the requirement, just stop and return
+		if nonZerosCount >= nonZeroCountTarget {
+			return det, nonZerosCount
+		}
+		// at this point, even all left are ok, the total is still smaller than target, just stop!
+		if nonZerosCount+(256-i-dim) < nonZeroCountTarget {
+			return det, nonZerosCount
 		}
 	}
 	return ret, nonZerosCount


### PR DESCRIPTION
As written in the title, it seems that the first submatrix does not contribute to MPoW at all.
I suggest skipping the first submatrix.
This will cut down on nominal calculation of determinants.